### PR TITLE
fix(settings): avoid reusing default settings object

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module "*.png" {
+    const src: string;
+    export default src;
+}

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -3,10 +3,10 @@ import { handleRedirect } from "./lib";
 import type { Settings } from "./settings";
 
 describe("handleRedirect", () => {
-    let mockRedirectCallback: () => void;
+    let mockRedirectCallback: ReturnType<typeof vi.fn<(url: string) => void>>;
 
     beforeEach(() => {
-        mockRedirectCallback = vi.fn();
+        mockRedirectCallback = vi.fn<(url: string) => void>();
     });
 
     const createSettings = (overrides: Partial<Settings> = {}): (() => Promise<Settings>) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,15 +19,17 @@ const DEFAULT_SETTINGS = {
 export type Settings = typeof DEFAULT_SETTINGS;
 export type SettingKeys = keyof typeof DEFAULT_SETTINGS;
 
+const createSettings = (settings: unknown = {}): Settings => ({
+    ...DEFAULT_SETTINGS,
+    ...(settings && typeof settings === "object" ? settings : {}),
+});
+
 export const getSettings = async () => {
     try {
         const stored = await store.get(SETTINGS_KEY);
-        return Object.entries(stored).reduce<Settings>((acc, [key, value]) => {
-            if (key in DEFAULT_SETTINGS) acc[key] = !!value;
-            return acc;
-        }, DEFAULT_SETTINGS);
+        return createSettings(stored);
     } catch {
-        return DEFAULT_SETTINGS;
+        return createSettings();
     }
 };
 
@@ -59,32 +61,26 @@ const handleRulesetUpdates = async (settings: Settings) => {
 };
 
 export const setSettings = async (settings: Settings) => {
-    const value = Object.entries(settings).reduce<Settings>((acc, [key, value]) => {
-        if (key in DEFAULT_SETTINGS) acc[key] = !!value;
-        return acc;
-    }, DEFAULT_SETTINGS);
+    const value = createSettings(settings);
 
     await store.set(SETTINGS_KEY, value);
-    handleRulesetUpdates(value);
+    await handleRulesetUpdates(value);
 };
 
-export const useSettings = () => {
-    const [storeSettings, setStoreSettings] = useStorage(
+export const useSettings = (): [Settings, (settings: Settings) => Promise<void>] => {
+    const [storeSettings, setStoreSettings] = useStorage<Settings>(
         {
             key: SETTINGS_KEY,
             instance: store,
         },
-        (value) => (typeof value === "undefined" ? DEFAULT_SETTINGS : value),
+        createSettings,
     );
 
     const setSettings = async (settings: Settings) => {
-        const value = Object.entries(settings).reduce<Settings>((acc, [key, value]) => {
-            if (key in DEFAULT_SETTINGS) acc[key] = !!value;
-            return acc;
-        }, DEFAULT_SETTINGS);
+        const value = createSettings(settings);
 
-        setStoreSettings(value);
-        handleRulesetUpdates(value);
+        await setStoreSettings(value);
+        await handleRulesetUpdates(value);
     };
 
     return [storeSettings, setSettings];


### PR DESCRIPTION
Fixes settings updates not reliably triggering popup rerenders.

## Issues

Previously, several settings paths used `reduce(..., DEFAULT_SETTINGS)` to build the next settings object. That reused `DEFAULT_SETTINGS` as the accumulator and mutated the same object reference. 

As a result, storage could be updated while React / `useStorage` still observed the same object reference, so the popup did not consistently rerender.

## Changes

Added `createSettings` to merge stored settings with `DEFAULT_SETTINGS` into a new object.

